### PR TITLE
Fix settings detection on non-windows systems

### DIFF
--- a/plex_rd.py
+++ b/plex_rd.py
@@ -1157,7 +1157,7 @@ class ui:
                 option.input()
         ui.options()
     def setup():
-        if os.path.exists('.\settings.json'):
+        if os.path.exists('./settings.json'):
             with open('settings.json', 'r') as f:
                 settings = json.loads(f.read())
             if settings['Show Menu on Startup'] == "false":


### PR DESCRIPTION
On Linux (and I believe macOS as well), os.path.exists('.\settings.json') will return false even if the file exists.

However, os.path.exists('./settings.json') works on Linux, macOS, and Windows, maximizing compatibility.